### PR TITLE
Fixed "ReferenceError: primordials is not defined" while running gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.html",
   "devDependencies": {
     "del": "^2.2.0",
-    "gulp": "^3.9.1",
+    "gulp": "4.0.2",
+    "graceful-fs": "4.2.2",
     "gulp-htmlmin": "^1.3.0",
     "gulp-imagemin": "^2.4.0",
     "gulp-inline-source": "^2.1.0",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3125771/138250344-7cff36ad-cb11-420e-96f1-9a3b16b6fa47.png)
